### PR TITLE
Fixed Bug where the Client crashes with a NullPointerException while …

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/object/Bullet.java
+++ b/src/main/java/com/mrcrayfish/guns/object/Bullet.java
@@ -50,6 +50,8 @@ public class Bullet
 
     public void tick(World world)
     {
+        if(world == null)
+            return;
         if(this.projectile == null)
         {
             Entity entity = world.getEntityByID(this.entityId);


### PR DESCRIPTION
…disconnecting

I got this error:
`Time: 2020-04-19 21:33:12 CEST
Description: Unexpected error

java.lang.NullPointerException
    at com.mrcrayfish.guns.object.Bullet.tick(Bullet.java:55)
    at com.mrcrayfish.guns.client.event.RenderEvents.lambda$onTickBullets$0(RenderEvents.java:1040)
    at com.mrcrayfish.guns.client.event.RenderEvents$$Lambda$4699/1767584718.accept(Unknown Source)
    at java.util.ArrayList.forEach(ArrayList.java:1249)
    at com.mrcrayfish.guns.client.event.RenderEvents.onTickBullets(RenderEvents.java:1040)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_1668_RenderEvents_onTickBullets_ClientTickEvent.invoke(.dynamic)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
    at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:182)
    at net.minecraftforge.fml.common.FMLCommonHandler.onPostClientTick(FMLCommonHandler.java:349)
    at net.minecraft.client.Minecraft.runTick(Minecraft.java:1911)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1098)
    at net.minecraft.client.Minecraft.run(Minecraft.java:3942)
    at net.minecraft.client.main.Main.main(SourceFile:123)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)

`
while disconnecting. I was playing on a Modded Server with 150 Mods and the disconnecting took a while. That was probably the problem. The nullpointer can only be in the world parameter. So I added a "world== null return" statement