### PR TITLE
Create workbench.json

### DIFF
--- a/src/main/resources/data/cgm/advancements/recipes/workbench.json
+++ b/src/main/resources/data/cgm/advancements/recipes/workbench.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "cgm:workbench"
+    ]
+  },
+  "criteria": {
+    "has_concrete": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:light_gray_concrete"
+          }
+        ]
+      }
+    },
+    "has_iron": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:iron_ingot"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "cgm:workbench"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_concrete",
+      "has_iron",
+      "has_the_recipe"
+    ]
+  ]
+}


### PR DESCRIPTION
This allows the player to unlock the workbench recipe in the recipe book once they obtain iron or light gray concrete instead of just once they craft the workbench.