### PR TITLE
[1.16.X] Added an event to cancel gun firing

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/client/event/GunHandler.java
+++ b/src/main/java/com/mrcrayfish/guns/client/event/GunHandler.java
@@ -6,6 +6,7 @@ import com.mrcrayfish.guns.Config;
 import com.mrcrayfish.guns.GunMod;
 import com.mrcrayfish.guns.Reference;
 import com.mrcrayfish.guns.client.ClientHandler;
+import com.mrcrayfish.guns.hook.GunFireEvent;
 import com.mrcrayfish.guns.item.GunItem;
 import com.mrcrayfish.guns.network.PacketHandler;
 import com.mrcrayfish.guns.network.message.MessageShoot;
@@ -19,6 +20,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.CooldownTracker;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.InputEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -180,6 +182,9 @@ public class GunHandler
             GunItem gunItem = (GunItem) heldItem.getItem();
             Gun modifiedGun = gunItem.getModifiedGun(heldItem);
 
+            if(MinecraftForge.EVENT_BUS.post(new GunFireEvent.Pre(player, heldItem)))
+                return;
+
             int rate = GunEnchantmentHelper.getRate(heldItem, modifiedGun);
             rate = GunModifierHelper.getModifiedRate(heldItem, rate);
             tracker.setCooldown(heldItem.getItem(), rate);
@@ -196,6 +201,8 @@ public class GunHandler
                 recoil = modifiedGun.getGeneral().getRecoilAngle() * recoilModifier;
                 progressRecoil = 0F;
             }
+
+            MinecraftForge.EVENT_BUS.post(new GunFireEvent.Post(player, heldItem));
         }
     }
 

--- a/src/main/java/com/mrcrayfish/guns/common/CommonHandler.java
+++ b/src/main/java/com/mrcrayfish/guns/common/CommonHandler.java
@@ -93,6 +93,9 @@ public class CommonHandler
                 Gun modifiedGun = item.getModifiedGun(heldItem);
                 if(modifiedGun != null)
                 {
+                    if(MinecraftForge.EVENT_BUS.post(new GunFireEvent.Pre(player, heldItem)))
+                        return;
+
                     /* Updates the yaw and pitch with the clients current yaw and pitch */
                     player.rotationYaw = message.getRotationYaw();
                     player.rotationPitch = message.getRotationPitch();
@@ -132,7 +135,7 @@ public class CommonHandler
                         }
                     }
 
-                    MinecraftForge.EVENT_BUS.post(new GunFireEvent(player, heldItem));
+                    MinecraftForge.EVENT_BUS.post(new GunFireEvent.Post(player, heldItem));
 
                     if(Config.COMMON.aggroMobs.enabled.get())
                     {

--- a/src/main/java/com/mrcrayfish/guns/hook/GunFireEvent.java
+++ b/src/main/java/com/mrcrayfish/guns/hook/GunFireEvent.java
@@ -3,6 +3,7 @@ package com.mrcrayfish.guns.hook;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * <p>Fired when a player shoots a gun.</p>
@@ -25,5 +26,32 @@ public class GunFireEvent extends PlayerEvent
     public ItemStack getStack()
     {
         return stack;
+    }
+
+    /**
+     * <p>Fired when a player is about to shoot a bullet.</p>
+     *
+     * @author Ocelot
+     */
+    @Cancelable
+    public static class Pre extends GunFireEvent
+    {
+        public Pre(PlayerEntity player, ItemStack stack)
+        {
+            super(player, stack);
+        }
+    }
+
+    /**
+     * <p>Fired after a player has shot a bullet.</p>
+     *
+     * @author Ocelot
+     */
+    public static class Post extends GunFireEvent
+    {
+        public Post(PlayerEntity player, ItemStack stack)
+        {
+            super(player, stack);
+        }
     }
 }


### PR DESCRIPTION
This PR adds in a pre and post to the gun fire event server and client side. This allows the prevention of bullet firing based on specified conditions.