### PR TITLE
[1.16.X] Added support for binding curse on attachments

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/common/container/slot/AttachmentSlot.java
+++ b/src/main/java/com/mrcrayfish/guns/common/container/slot/AttachmentSlot.java
@@ -5,6 +5,7 @@ import com.mrcrayfish.guns.init.ModSounds;
 import com.mrcrayfish.guns.item.GunItem;
 import com.mrcrayfish.guns.item.attachment.IAttachment;
 import com.mrcrayfish.guns.object.Gun;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.container.Slot;
@@ -67,5 +68,12 @@ public class AttachmentSlot extends Slot
     public int getSlotStackLimit()
     {
         return 1;
+    }
+
+    @Override
+    public boolean canTakeStack(PlayerEntity player)
+    {
+        ItemStack itemstack = this.getStack();
+        return (itemstack.isEmpty() || player.isCreative() || !EnchantmentHelper.hasBindingCurse(itemstack)) && super.canTakeStack(player);
     }
 }

--- a/src/main/java/com/mrcrayfish/guns/item/BarrelItem.java
+++ b/src/main/java/com/mrcrayfish/guns/item/BarrelItem.java
@@ -2,6 +2,8 @@ package com.mrcrayfish.guns.item;
 
 import com.mrcrayfish.guns.item.attachment.IBarrel;
 import com.mrcrayfish.guns.item.attachment.impl.Barrel;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -39,5 +41,11 @@ public class BarrelItem extends Item implements IBarrel, IColored
     public boolean canColor(ItemStack stack)
     {
         return this.colored;
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+    {
+        return enchantment == Enchantments.BINDING_CURSE || super.canApplyAtEnchantingTable(stack, enchantment);
     }
 }

--- a/src/main/java/com/mrcrayfish/guns/item/ScopeItem.java
+++ b/src/main/java/com/mrcrayfish/guns/item/ScopeItem.java
@@ -2,6 +2,8 @@ package com.mrcrayfish.guns.item;
 
 import com.mrcrayfish.guns.item.attachment.IScope;
 import com.mrcrayfish.guns.item.attachment.impl.Scope;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -39,5 +41,11 @@ public class ScopeItem extends Item implements IScope, IColored
     public boolean canColor(ItemStack stack)
     {
         return this.colored;
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+    {
+        return enchantment == Enchantments.BINDING_CURSE || super.canApplyAtEnchantingTable(stack, enchantment);
     }
 }

--- a/src/main/java/com/mrcrayfish/guns/item/StockItem.java
+++ b/src/main/java/com/mrcrayfish/guns/item/StockItem.java
@@ -2,6 +2,8 @@ package com.mrcrayfish.guns.item;
 
 import com.mrcrayfish.guns.item.attachment.IStock;
 import com.mrcrayfish.guns.item.attachment.impl.Stock;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -39,5 +41,11 @@ public class StockItem extends Item implements IStock, IColored
     public boolean canColor(ItemStack stack)
     {
         return this.colored;
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+    {
+        return enchantment == Enchantments.BINDING_CURSE || super.canApplyAtEnchantingTable(stack, enchantment);
     }
 }

--- a/src/main/java/com/mrcrayfish/guns/item/UnderBarrelItem.java
+++ b/src/main/java/com/mrcrayfish/guns/item/UnderBarrelItem.java
@@ -2,6 +2,8 @@ package com.mrcrayfish.guns.item;
 
 import com.mrcrayfish.guns.item.attachment.IUnderBarrel;
 import com.mrcrayfish.guns.item.attachment.impl.UnderBarrel;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -39,5 +41,11 @@ public class UnderBarrelItem extends Item implements IUnderBarrel, IColored
     public boolean canColor(ItemStack stack)
     {
         return this.colored;
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+    {
+        return enchantment == Enchantments.BINDING_CURSE || super.canApplyAtEnchantingTable(stack, enchantment);
     }
 }


### PR DESCRIPTION
This PR adds in support for curse of binding forcing attachments to stay on guns. This could be used to force a scope or silencer onto a gun.