### PR TITLE
[1.16.X] Fixed blinded screen rendering over GUI

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/client/event/GunRenderer.java
+++ b/src/main/java/com/mrcrayfish/guns/client/event/GunRenderer.java
@@ -962,31 +962,6 @@ public class GunRenderer
         matrixStack.pop();
     }
 
-    @SubscribeEvent(priority = EventPriority.LOWEST, receiveCanceled = true)
-    public void blindPlayer(TickEvent.RenderTickEvent event)
-    {
-        if(event.phase != TickEvent.Phase.END)
-        {
-            return;
-        }
-
-        if(Minecraft.getInstance().player == null)
-        {
-            return;
-        }
-
-        EffectInstance effect = Minecraft.getInstance().player.getActivePotionEffect(ModEffects.BLINDED.get());
-        if(effect != null)
-        {
-            // Render white screen-filling overlay at full alpha effect when duration is above threshold
-            // When below threshold, fade to full transparency as duration approaches 0
-            float percent = Math.min((effect.getDuration() / (float) Config.SERVER.alphaFadeThreshold.get()), 1);
-            MainWindow window = Minecraft.getInstance().getMainWindow();
-            MatrixStack matrixStack = new MatrixStack();
-            Screen.fill(matrixStack, 0, 0, window.getWidth(), window.getHeight(), ((int) (percent * Config.SERVER.alphaOverlay.get() + 0.5) << 24) | 16777215);
-        }
-    }
-
     /**
      *
      * @param sensitivity

--- a/src/main/java/com/mrcrayfish/guns/mixin/client/GameRendererMixin.java
+++ b/src/main/java/com/mrcrayfish/guns/mixin/client/GameRendererMixin.java
@@ -1,0 +1,40 @@
+package com.mrcrayfish.guns.mixin.client;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mrcrayfish.guns.Config;
+import com.mrcrayfish.guns.init.ModEffects;
+import net.minecraft.client.MainWindow;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.AbstractGui;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.potion.EffectInstance;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GameRenderer.class)
+public class GameRendererMixin
+{
+    @Inject(method = "updateCameraAndRender", at = @At(value = "INVOKE", target = "Lnet/minecraft/profiler/IProfiler;endStartSection(Ljava/lang/String;)V", shift = At.Shift.AFTER))
+    public void updateCameraAndRender(float partialTicks, long nanoTime, boolean renderWorldIn, CallbackInfo ci)
+    {
+        Minecraft minecraft = Minecraft.getInstance();
+        PlayerEntity player = minecraft.player;
+        if (player == null)
+        {
+            return;
+        }
+
+        EffectInstance effect = player.getActivePotionEffect(ModEffects.BLINDED.get());
+        if (effect != null)
+        {
+            // Render white screen-filling overlay at full alpha effect when duration is above threshold
+            // When below threshold, fade to full transparency as duration approaches 0
+            float percent = Math.min((effect.getDuration() / (float) Config.SERVER.alphaFadeThreshold.get()), 1);
+            MainWindow window = Minecraft.getInstance().getMainWindow();
+            AbstractGui.fill(new MatrixStack(), 0, 0, window.getWidth(), window.getHeight(), ((int) (percent * Config.SERVER.alphaOverlay.get() + 0.5) << 24) | 16777215);
+        }
+    }
+}

--- a/src/main/resources/cgm.mixins.json
+++ b/src/main/resources/cgm.mixins.json
@@ -1,17 +1,18 @@
 {
-    "required": true,
-    "package": "com.mrcrayfish.guns.mixin",
-    "compatibilityLevel": "JAVA_8",
-    "minVersion": "0.8",
-    "refmap": "cgm.refmap.json",
-    "mixins": [
-        "common.LivingEntityMixin",
-        "common.PlayerListMixin"
-    ],
-    "client": [
-        "client.MouseHelperMixin"
-    ],
-    "injectors": {
-        "defaultRequire": 1
-    }
+  "required": true,
+  "package": "com.mrcrayfish.guns.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "minVersion": "0.8",
+  "refmap": "cgm.refmap.json",
+  "mixins": [
+    "common.LivingEntityMixin",
+    "common.PlayerListMixin"
+  ],
+  "client": [
+    "client.GameRendererMixin",
+    "client.MouseHelperMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
 }


### PR DESCRIPTION
This PR replaces the hack for rendering the blindness quad by mixing just before the GUI is rendered. This fixes the issue where the inventory would behave oddly while blinded.