### PR TITLE
[1.16.X] Fixed ammo only increasing by 1 in creative

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/object/Gun.java
+++ b/src/main/java/com/mrcrayfish/guns/object/Gun.java
@@ -1105,7 +1105,7 @@ public final class Gun implements INBTSerializable<CompoundNBT>
         if(player.isCreative())
         {
             Item item = ForgeRegistries.ITEMS.getValue(id);
-            return item != null ? new ItemStack(item) : ItemStack.EMPTY;
+            return item != null ? new ItemStack(item, Integer.MAX_VALUE) : ItemStack.EMPTY;
         }
         for(int i = 0; i < player.inventory.getSizeInventory(); ++i)
         {


### PR DESCRIPTION
This PR fixes an error in a previous PR where the stack size of the ammo item in `Gun` was set to 1 instead of the max stack size.