### PR TITLE
[1.16.X] Added gun reload event

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/GunMod.java
+++ b/src/main/java/com/mrcrayfish/guns/GunMod.java
@@ -54,7 +54,6 @@ public class GunMod
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.commonSpec);
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, Config.serverSpec);
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        bus.register(this);
         ModBlocks.REGISTER.register(bus);
         ModContainers.REGISTER.register(bus);
         ModEffects.REGISTER.register(bus);

--- a/src/main/java/com/mrcrayfish/guns/client/handler/ReloadHandler.java
+++ b/src/main/java/com/mrcrayfish/guns/client/handler/ReloadHandler.java
@@ -2,6 +2,7 @@ package com.mrcrayfish.guns.client.handler;
 
 import com.mrcrayfish.guns.client.KeyBinds;
 import com.mrcrayfish.guns.common.Gun;
+import com.mrcrayfish.guns.event.GunReloadEvent;
 import com.mrcrayfish.guns.init.ModSyncedDataKeys;
 import com.mrcrayfish.guns.item.GunItem;
 import com.mrcrayfish.guns.network.PacketHandler;
@@ -14,6 +15,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraftforge.client.event.InputEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -40,7 +42,9 @@ public class ReloadHandler
     private int prevReloadTimer;
     private int reloadingSlot;
 
-    private ReloadHandler() {}
+    private ReloadHandler()
+    {
+    }
 
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent event)
@@ -113,9 +117,12 @@ public class ReloadHandler
                         {
                             return;
                         }
+                        if(MinecraftForge.EVENT_BUS.post(new GunReloadEvent.Pre(player, stack)))
+                            return;
                         SyncedPlayerData.instance().set(player, ModSyncedDataKeys.RELOADING, true);
                         PacketHandler.getPlayChannel().sendToServer(new MessageReload(true));
                         this.reloadingSlot = player.inventory.currentItem;
+                        MinecraftForge.EVENT_BUS.post(new GunReloadEvent.Post(player, stack));
                     }
                 }
             }

--- a/src/main/java/com/mrcrayfish/guns/event/GunReloadEvent.java
+++ b/src/main/java/com/mrcrayfish/guns/event/GunReloadEvent.java
@@ -6,22 +6,22 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * <p>Fired when a player shoots a gun.</p>
+ * <p>Fired when a player reloads a gun.</p>
  *
  * @author Ocelot
  */
-public class GunFireEvent extends PlayerEvent
+public class GunReloadEvent extends PlayerEvent
 {
     private final ItemStack stack;
 
-    public GunFireEvent(PlayerEntity player, ItemStack stack)
+    public GunReloadEvent(PlayerEntity player, ItemStack stack)
     {
         super(player);
         this.stack = stack;
     }
 
     /**
-     * @return The stack the player was holding when firing the gun
+     * @return The stack the player was holding when reloading the gun
      */
     public ItemStack getStack()
     {
@@ -37,12 +37,12 @@ public class GunFireEvent extends PlayerEvent
     }
 
     /**
-     * <p>Fired when a player is about to shoot a bullet.</p>
+     * <p>Fired when a player is about to reload a gun.</p>
      *
      * @author Ocelot
      */
     @Cancelable
-    public static class Pre extends GunFireEvent
+    public static class Pre extends GunReloadEvent
     {
         public Pre(PlayerEntity player, ItemStack stack)
         {
@@ -51,11 +51,11 @@ public class GunFireEvent extends PlayerEvent
     }
 
     /**
-     * <p>Fired after a player has shot a bullet.</p>
+     * <p>Fired after a player has started reloading a gun.</p>
      *
      * @author Ocelot
      */
-    public static class Post extends GunFireEvent
+    public static class Post extends GunReloadEvent
     {
         public Post(PlayerEntity player, ItemStack stack)
         {

--- a/src/main/java/com/mrcrayfish/guns/network/message/MessageReload.java
+++ b/src/main/java/com/mrcrayfish/guns/network/message/MessageReload.java
@@ -1,9 +1,12 @@
 package com.mrcrayfish.guns.network.message;
 
+import com.mrcrayfish.guns.event.GunReloadEvent;
 import com.mrcrayfish.guns.init.ModSyncedDataKeys;
 import com.mrcrayfish.obfuscate.common.data.SyncedPlayerData;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.network.NetworkEvent;
 
 import java.util.function.Supplier;
@@ -15,7 +18,9 @@ public class MessageReload implements IMessage
 {
     private boolean reload;
 
-    public MessageReload() {}
+    public MessageReload()
+    {
+    }
 
     public MessageReload(boolean reload)
     {
@@ -42,7 +47,17 @@ public class MessageReload implements IMessage
             ServerPlayerEntity player = supplier.get().getSender();
             if(player != null && !player.isSpectator())
             {
-                SyncedPlayerData.instance().set(player, ModSyncedDataKeys.RELOADING, this.reload);
+                SyncedPlayerData.instance().set(player, ModSyncedDataKeys.RELOADING, this.reload); // This has to be set in order to verify the packet is sent if the event is cancelled
+                if(!this.reload)
+                    return;
+
+                ItemStack gun = player.getHeldItemMainhand();
+                if(MinecraftForge.EVENT_BUS.post(new GunReloadEvent.Pre(player, gun)))
+                {
+                    SyncedPlayerData.instance().set(player, ModSyncedDataKeys.RELOADING, false);
+                    return;
+                }
+                MinecraftForge.EVENT_BUS.post(new GunReloadEvent.Post(player, gun));
             }
         });
         supplier.get().setPacketHandled(true);


### PR DESCRIPTION
This PR adds an event fired just before a gun is reloaded and just after on both sides. This allows the complete cancelation of a reload.