### PR TITLE
Update ReloadTracker, so addons can access to it

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/common/ReloadTracker.java
+++ b/src/main/java/com/mrcrayfish/guns/common/ReloadTracker.java
@@ -44,7 +44,12 @@ public class ReloadTracker
         this.stack = player.inventory.getCurrentItem();
         this.gun = ((GunItem) stack.getItem()).getModifiedGun(stack);
     }
-
+    
+    public static Map<PlayerEntity, ReloadTracker> getReloadTrackerMap()
+    {
+        return RELOAD_TRACKER_MAP;
+    }
+    
     /**
      * Tests if the current item the player is holding is the same as the one being reloaded
      *


### PR DESCRIPTION
Added a public method to get the 'RELOAD_TRACKER_MAP', To allow addons freely control the reloads. (yeh)