### PR TITLE
[1.16.X] Made GunProjectileHitEvent cancelable

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
@@ -419,7 +419,10 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
 
     private void onHit(RayTraceResult result, Vector3d startVec, Vector3d endVec)
     {
-        MinecraftForge.EVENT_BUS.post(new GunProjectileHitEvent(result, this));
+        if(MinecraftForge.EVENT_BUS.post(new GunProjectileHitEvent(result, this)))
+        {
+            return;
+        }
 
         if(result instanceof BlockRayTraceResult)
         {

--- a/src/main/java/com/mrcrayfish/guns/event/GunProjectileHitEvent.java
+++ b/src/main/java/com/mrcrayfish/guns/event/GunProjectileHitEvent.java
@@ -2,6 +2,7 @@ package com.mrcrayfish.guns.event;
 
 import com.mrcrayfish.guns.entity.ProjectileEntity;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
@@ -9,6 +10,7 @@ import net.minecraftforge.eventbus.api.Event;
  *
  * @author Ocelot
  */
+@Cancelable
 public class GunProjectileHitEvent extends Event
 {
     private final RayTraceResult result;


### PR DESCRIPTION
This PR allows cancellation of hitting an entity with a projectile making it pass through the entity.