### PR TITLE
[1.16.X] Fixed explosions not destroying IExplosionDamageable blocks

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
@@ -784,12 +784,6 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
         explosion.doExplosionA();
         explosion.doExplosionB(true);
 
-        // Clears the affected blocks if mode is none
-        if(mode == Explosion.Mode.NONE)
-        {
-            explosion.clearAffectedBlockPositions();
-        }
-
         // Send event to blocks that are exploded (none if mode is none)
         explosion.getAffectedBlockPositions().forEach(pos ->
         {
@@ -798,6 +792,12 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
                 ((IExplosionDamageable) world.getBlockState(pos).getBlock()).onProjectileExploded(world, world.getBlockState(pos), pos, entity);
             }
         });
+
+        // Clears the affected blocks if mode is none
+        if(mode == Explosion.Mode.NONE)
+        {
+            explosion.clearAffectedBlockPositions();
+        }
 
         for(ServerPlayerEntity player : ((ServerWorld) world).getPlayers())
         {


### PR DESCRIPTION
This PR allows blocks designed to explode when griefing is off to still explode if they need to.