### PR TITLE
Fix gun data ignoring mod id's

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/common/NetworkGunManager.java
+++ b/src/main/java/com/mrcrayfish/guns/common/NetworkGunManager.java
@@ -84,6 +84,10 @@ public class NetworkGunManager extends SimplePreparableReloadListener<Map<GunIte
                     if(!id.getPath().equals(splitPath[splitPath.length - 1]))
                         return;
 
+                    // Also check if the mod id matches with the gun's registered namespace
+                    if (!id.getNamespace().equals(resourceLocation.getNamespace()))
+                        return;
+
                     manager.getResource(resourceLocation).ifPresent(resource ->
                     {
                         try(Reader reader = new BufferedReader(new InputStreamReader(resource.open(), StandardCharsets.UTF_8)))


### PR DESCRIPTION
Added missing mod id check in the NetworkGunManager. This fixes the add-on incompatability I reported earlier, allowing Project Arsenal and Additional Guns (and possible other add-ons) to be used together without issue.

It would be appreciated if this small (but important) fix can also be applied to 1.16.x and 1.18.x.

Fixes #392 