### PR TITLE
Unhardcoded the glass breaking mechanic

### DIFF
--- a/src/generated/resources/data/cgm/tags/blocks/fragile.json
+++ b/src/generated/resources/data/cgm/tags/blocks/fragile.json
@@ -1,12 +1,9 @@
 {
-  "replace": true,
   "values": [
-    "#forge:glass",
     "#forge:glass_panes",
+    "#forge:glass",
     "#minecraft:candles",
     "minecraft:lily_pad",
-    "minecraft:big_dripleaf",
-    "minecraft:big_dripleaf_stem",
     "minecraft:cocoa",
     "minecraft:end_rod",
     "minecraft:scaffolding",
@@ -14,6 +11,17 @@
     "minecraft:turtle_egg",
     "minecraft:glowstone",
     "minecraft:sea_lantern",
-    "minecraft:ice"
+    "minecraft:ice",
+    "minecraft:blue_ice",
+    "minecraft:frosted_ice",
+    "minecraft:packed_ice",
+    "minecraft:bamboo",
+    "minecraft:small_amethyst_bud",
+    "minecraft:medium_amethyst_bud",
+    "minecraft:large_amethyst_bud",
+    "minecraft:amethyst_cluster",
+    "minecraft:lantern",
+    "minecraft:soul_lantern",
+    "minecraft:pointed_dripstone"
   ]
 }

--- a/src/generated/resources/data/cgm/tags/blocks/fragile.json
+++ b/src/generated/resources/data/cgm/tags/blocks/fragile.json
@@ -1,0 +1,19 @@
+{
+  "replace": true,
+  "values": [
+    "#forge:glass",
+    "#forge:glass_panes",
+    "#minecraft:candles",
+    "minecraft:lily_pad",
+    "minecraft:big_dripleaf",
+    "minecraft:big_dripleaf_stem",
+    "minecraft:cocoa",
+    "minecraft:end_rod",
+    "minecraft:scaffolding",
+    "minecraft:sea_pickle",
+    "minecraft:turtle_egg",
+    "minecraft:glowstone",
+    "minecraft:sea_lantern",
+    "minecraft:ice"
+  ]
+}

--- a/src/main/java/com/mrcrayfish/guns/Config.java
+++ b/src/main/java/com/mrcrayfish/guns/Config.java
@@ -223,6 +223,7 @@ public class Config
         public final ForgeConfigSpec.DoubleValue breakingChance;
         public final ForgeConfigSpec.BooleanValue hardnessBreak;
         public final ForgeConfigSpec.DoubleValue guaranteeMinimum;
+        public final ForgeConfigSpec.DoubleValue unbreakableHardness;
         public final ForgeConfigSpec.BooleanValue setFireToBlocks;
 
         public Griefing(ForgeConfigSpec.Builder builder)
@@ -235,6 +236,7 @@ public class Config
                 this.breakingChance = builder.comment("Chance for a fragile block to break").defineInRange("breakingChance", 1.0, 0.0, 1.0);
                 this.hardnessBreak = builder.comment("If enabled, breaking chance depend on the hardness of the block").define("hardnessBreak", false);
                 this.guaranteeMinimum = builder.comment("Minimum hardness at which a block will break, -1 to disable").defineInRange("guaranteeMinimum", 0.5, -1.0, Float.MAX_VALUE);
+                this.unbreakableHardness = builder.comment("How strong are unbreakable blocks against bullets").defineInRange("unbreakableHardness", 100000.0, -1.0, Float.MAX_VALUE);
                 this.setFireToBlocks = builder.comment("If true, allows guns enchanted with Fire Starter to light and spread fires on blocks").define("setFireToBlocks", true);
             }
             builder.pop();

--- a/src/main/java/com/mrcrayfish/guns/Config.java
+++ b/src/main/java/com/mrcrayfish/guns/Config.java
@@ -219,11 +219,8 @@ public class Config
     {
         public final ForgeConfigSpec.BooleanValue enableBlockRemovalOnExplosions;
         public final ForgeConfigSpec.BooleanValue enableGlassBreaking;
-        public final ForgeConfigSpec.BooleanValue fragileDrops;
-        public final ForgeConfigSpec.DoubleValue breakingChance;
-        public final ForgeConfigSpec.BooleanValue hardnessBreak;
-        public final ForgeConfigSpec.DoubleValue guaranteeMinimum;
-        public final ForgeConfigSpec.DoubleValue unbreakableHardness;
+        public final ForgeConfigSpec.BooleanValue fragileBlockDrops;
+        public final ForgeConfigSpec.DoubleValue fragileBaseBreakChance;
         public final ForgeConfigSpec.BooleanValue setFireToBlocks;
 
         public Griefing(ForgeConfigSpec.Builder builder)
@@ -232,11 +229,8 @@ public class Config
             {
                 this.enableBlockRemovalOnExplosions = builder.comment("If enabled, allows block removal on explosions").define("enableBlockRemovalOnExplosions", true);
                 this.enableGlassBreaking = builder.comment("If enabled, allows guns to shoot out glass and other fragile objects").define("enableGlassBreaking", true);
-                this.fragileDrops = builder.comment("If enabled, broken fragile block will drop").define("fragileDrops", true);
-                this.breakingChance = builder.comment("Chance for a fragile block to break").defineInRange("breakingChance", 1.0, 0.0, 1.0);
-                this.hardnessBreak = builder.comment("If enabled, breaking chance depend on the hardness of the block").define("hardnessBreak", false);
-                this.guaranteeMinimum = builder.comment("Minimum hardness at which a block will break, -1 to disable").defineInRange("guaranteeMinimum", 0.5, -1.0, Float.MAX_VALUE);
-                this.unbreakableHardness = builder.comment("How strong are unbreakable blocks against bullets").defineInRange("unbreakableHardness", 100000.0, -1.0, Float.MAX_VALUE);
+                this.fragileBlockDrops = builder.comment("If enabled, fragile blocks will drop their loot when broken").define("fragileBlockDrops", true);
+                this.fragileBaseBreakChance = builder.comment("The chance that a fragile block is broken when impacted by a bullet").defineInRange("fragileBlockBreakChance", 1.0, 0.0, 1.0);
                 this.setFireToBlocks = builder.comment("If true, allows guns enchanted with Fire Starter to light and spread fires on blocks").define("setFireToBlocks", true);
             }
             builder.pop();

--- a/src/main/java/com/mrcrayfish/guns/Config.java
+++ b/src/main/java/com/mrcrayfish/guns/Config.java
@@ -219,6 +219,10 @@ public class Config
     {
         public final ForgeConfigSpec.BooleanValue enableBlockRemovalOnExplosions;
         public final ForgeConfigSpec.BooleanValue enableGlassBreaking;
+        public final ForgeConfigSpec.BooleanValue fragileDrops;
+        public final ForgeConfigSpec.DoubleValue breakingChance;
+        public final ForgeConfigSpec.BooleanValue hardnessBreak;
+        public final ForgeConfigSpec.DoubleValue guaranteeMinimum;
         public final ForgeConfigSpec.BooleanValue setFireToBlocks;
 
         public Griefing(ForgeConfigSpec.Builder builder)
@@ -226,7 +230,11 @@ public class Config
             builder.comment("Properties related to gun griefing").push("griefing");
             {
                 this.enableBlockRemovalOnExplosions = builder.comment("If enabled, allows block removal on explosions").define("enableBlockRemovalOnExplosions", true);
-                this.enableGlassBreaking = builder.comment("If enabled, allows guns to shoot out glass").define("enableGlassBreaking", true);
+                this.enableGlassBreaking = builder.comment("If enabled, allows guns to shoot out glass and other fragile objects").define("enableGlassBreaking", true);
+                this.fragileDrops = builder.comment("If enabled, broken fragile block will drop").define("fragileDrops", true);
+                this.breakingChance = builder.comment("Chance for a fragile block to break").defineInRange("breakingChance", 1.0, 0.0, 1.0);
+                this.hardnessBreak = builder.comment("If enabled, breaking chance depend on the hardness of the block").define("hardnessBreak", false);
+                this.guaranteeMinimum = builder.comment("Minimum hardness at which a block will break, -1 to disable").defineInRange("guaranteeMinimum", 0.5, -1.0, Float.MAX_VALUE);
                 this.setFireToBlocks = builder.comment("If true, allows guns enchanted with Fire Starter to light and spread fires on blocks").define("setFireToBlocks", true);
             }
             builder.pop();

--- a/src/main/java/com/mrcrayfish/guns/Config.java
+++ b/src/main/java/com/mrcrayfish/guns/Config.java
@@ -230,7 +230,7 @@ public class Config
                 this.enableBlockRemovalOnExplosions = builder.comment("If enabled, allows block removal on explosions").define("enableBlockRemovalOnExplosions", true);
                 this.enableGlassBreaking = builder.comment("If enabled, allows guns to shoot out glass and other fragile objects").define("enableGlassBreaking", true);
                 this.fragileBlockDrops = builder.comment("If enabled, fragile blocks will drop their loot when broken").define("fragileBlockDrops", true);
-                this.fragileBaseBreakChance = builder.comment("The chance that a fragile block is broken when impacted by a bullet").defineInRange("fragileBlockBreakChance", 1.0, 0.0, 1.0);
+                this.fragileBaseBreakChance = builder.comment("The base chance that a fragile block is broken when impacted by a bullet. The hardness of a block will scale this value; the harder the block, the lower the final calculated chance will be.").defineInRange("fragileBlockBreakChance", 1.0, 0.0, 1.0);
                 this.setFireToBlocks = builder.comment("If true, allows guns enchanted with Fire Starter to light and spread fires on blocks").define("setFireToBlocks", true);
             }
             builder.pop();

--- a/src/main/java/com/mrcrayfish/guns/GunMod.java
+++ b/src/main/java/com/mrcrayfish/guns/GunMod.java
@@ -5,7 +5,6 @@ import com.mrcrayfish.guns.client.CustomGunManager;
 import com.mrcrayfish.guns.client.KeyBinds;
 import com.mrcrayfish.guns.client.SpecialModels;
 import com.mrcrayfish.guns.common.BoundingBoxManager;
-import com.mrcrayfish.guns.common.ModTags;
 import com.mrcrayfish.guns.common.ProjectileManager;
 import com.mrcrayfish.guns.crafting.WorkbenchIngredient;
 import com.mrcrayfish.guns.datagen.BlockTagGen;

--- a/src/main/java/com/mrcrayfish/guns/GunMod.java
+++ b/src/main/java/com/mrcrayfish/guns/GunMod.java
@@ -5,6 +5,7 @@ import com.mrcrayfish.guns.client.CustomGunManager;
 import com.mrcrayfish.guns.client.KeyBinds;
 import com.mrcrayfish.guns.client.SpecialModels;
 import com.mrcrayfish.guns.common.BoundingBoxManager;
+import com.mrcrayfish.guns.common.ModTags;
 import com.mrcrayfish.guns.common.ProjectileManager;
 import com.mrcrayfish.guns.crafting.WorkbenchIngredient;
 import com.mrcrayfish.guns.datagen.BlockTagGen;

--- a/src/main/java/com/mrcrayfish/guns/common/ModTags.java
+++ b/src/main/java/com/mrcrayfish/guns/common/ModTags.java
@@ -1,0 +1,17 @@
+package com.mrcrayfish.guns.common;
+
+import com.mrcrayfish.guns.Reference;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+
+public class ModTags {
+    public static class Blocks {
+        public static final TagKey<Block> FRAGILE = tag("fragile");
+
+        private static TagKey<Block> tag(String name) {
+            return TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(Reference.MOD_ID, name));
+        }
+    }
+}

--- a/src/main/java/com/mrcrayfish/guns/common/ModTags.java
+++ b/src/main/java/com/mrcrayfish/guns/common/ModTags.java
@@ -1,17 +1,20 @@
 package com.mrcrayfish.guns.common;
 
 import com.mrcrayfish.guns.Reference;
-import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
 
-public class ModTags {
-    public static class Blocks {
+public class ModTags
+{
+    public static class Blocks
+    {
         public static final TagKey<Block> FRAGILE = tag("fragile");
 
-        private static TagKey<Block> tag(String name) {
-            return TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(Reference.MOD_ID, name));
+        private static TagKey<Block> tag(String name)
+        {
+            return BlockTags.create(new ResourceLocation(Reference.MOD_ID, name));
         }
     }
 }

--- a/src/main/java/com/mrcrayfish/guns/datagen/BlockTagGen.java
+++ b/src/main/java/com/mrcrayfish/guns/datagen/BlockTagGen.java
@@ -24,14 +24,24 @@ public class BlockTagGen extends BlockTagsProvider
                 .addTag(Tags.Blocks.GLASS)
                 .addTag(BlockTags.CANDLES)
                 .add(Blocks.LILY_PAD)
-                .add(Blocks.BIG_DRIPLEAF)
-                .add(Blocks.BIG_DRIPLEAF_STEM)
                 .add(Blocks.COCOA)
                 .add(Blocks.END_ROD)
                 .add(Blocks.SCAFFOLDING)
                 .add(Blocks.SEA_PICKLE)
                 .add(Blocks.TURTLE_EGG)
                 .add(Blocks.GLOWSTONE)
-                .add(Blocks.SEA_LANTERN);
+                .add(Blocks.SEA_LANTERN)
+                .add(Blocks.ICE)
+                .add(Blocks.BLUE_ICE)
+                .add(Blocks.FROSTED_ICE)
+                .add(Blocks.PACKED_ICE)
+                .add(Blocks.BAMBOO)
+                .add(Blocks.SMALL_AMETHYST_BUD)
+                .add(Blocks.MEDIUM_AMETHYST_BUD)
+                .add(Blocks.LARGE_AMETHYST_BUD)
+                .add(Blocks.AMETHYST_CLUSTER)
+                .add(Blocks.LANTERN)
+                .add(Blocks.SOUL_LANTERN)
+                .add(Blocks.POINTED_DRIPSTONE);
     }
 }

--- a/src/main/java/com/mrcrayfish/guns/datagen/BlockTagGen.java
+++ b/src/main/java/com/mrcrayfish/guns/datagen/BlockTagGen.java
@@ -1,8 +1,13 @@
 package com.mrcrayfish.guns.datagen;
 
 import com.mrcrayfish.guns.Reference;
+import com.mrcrayfish.guns.common.ModTags;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.tags.BlockTagsProvider;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagBuilder;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ExistingFileHelper;
 
 public class BlockTagGen extends BlockTagsProvider
@@ -15,5 +20,19 @@ public class BlockTagGen extends BlockTagsProvider
     @Override
     protected void addTags()
     {
+        this.tag(ModTags.Blocks.FRAGILE)
+                .addTag(Tags.Blocks.GLASS_PANES)
+                .addTag(Tags.Blocks.GLASS)
+                .addTag(BlockTags.CANDLES)
+                .add(Blocks.LILY_PAD)
+                .add(Blocks.BIG_DRIPLEAF)
+                .add(Blocks.BIG_DRIPLEAF_STEM)
+                .add(Blocks.COCOA)
+                .add(Blocks.END_ROD)
+                .add(Blocks.SCAFFOLDING)
+                .add(Blocks.SEA_PICKLE)
+                .add(Blocks.TURTLE_EGG)
+                .add(Blocks.GLOWSTONE)
+                .add(Blocks.SEA_LANTERN);
     }
 }

--- a/src/main/java/com/mrcrayfish/guns/datagen/BlockTagGen.java
+++ b/src/main/java/com/mrcrayfish/guns/datagen/BlockTagGen.java
@@ -5,16 +5,15 @@ import com.mrcrayfish.guns.common.ModTags;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.tags.BlockTagsProvider;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.tags.TagBuilder;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ExistingFileHelper;
 
 public class BlockTagGen extends BlockTagsProvider
 {
-    public BlockTagGen(DataGenerator generatorIn, ExistingFileHelper existingFileHelper)
+    public BlockTagGen(DataGenerator generator, ExistingFileHelper existingFileHelper)
     {
-        super(generatorIn, Reference.MOD_ID, existingFileHelper);
+        super(generator, Reference.MOD_ID, existingFileHelper);
     }
 
     @Override

--- a/src/main/java/com/mrcrayfish/guns/datagen/ItemTagGen.java
+++ b/src/main/java/com/mrcrayfish/guns/datagen/ItemTagGen.java
@@ -1,6 +1,7 @@
 package com.mrcrayfish.guns.datagen;
 
 import com.mrcrayfish.guns.Reference;
+import com.mrcrayfish.guns.common.ModTags;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.tags.BlockTagsProvider;
 import net.minecraft.data.tags.ItemTagsProvider;

--- a/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
@@ -441,7 +441,7 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
                 float min = Config.COMMON.gameplay.griefing.guaranteeMinimum.get().floatValue();
                 // If min is under 0, it will still be 0 for this calculation
                 float total = speed - Math.max(0.0f, min);
-                // If min is under 0 (and so total is negative) 100% chance, otherwise, do the normal calculation
+                // If min is over or equal to speed (and so total is negative or zero) 100% chance, otherwise, do the normal calculation
                 float chance = speed <= min ? 1.0f : (Config.COMMON.gameplay.griefing.breakingChance.get().floatValue() / (total+1));
 
                 if (Math.random() < chance) this.level.destroyBlock(pos, Config.COMMON.gameplay.griefing.fragileDrops.get());

--- a/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
@@ -435,21 +435,16 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
 
             if(Config.COMMON.gameplay.griefing.enableGlassBreaking.get() && state.is(ModTags.Blocks.FRAGILE))
             {
-                boolean drops = Config.COMMON.gameplay.griefing.fragileDrops.get();
                 float speed = state.getDestroySpeed(getLevel(), pos);
+                // If speed is under 0, it will use the unbreakableHardness value
+                speed = speed < 0 ? Config.COMMON.gameplay.griefing.unbreakableHardness.get().floatValue() : speed;
                 float min = Config.COMMON.gameplay.griefing.guaranteeMinimum.get().floatValue();
-                float total = speed - min;
+                // If min is under 0, it will still be 0 for this calculation
+                float total = speed - Math.max(0.0f, min);
+                // If min is under 0 (and so total is negative) 100% chance, otherwise, do the normal calculation
+                float chance = speed <= min ? 1.0f : (Config.COMMON.gameplay.griefing.breakingChance.get().floatValue() / (total+1));
 
-                if (total < 0 && min >= 0) this.level.destroyBlock(pos, drops);
-
-                if (Config.COMMON.gameplay.griefing.hardnessBreak.get()){
-                    if (Math.random() * speed > total) // Stronger block will be less likely to break, also, a negative total will be an instant break
-                        this.level.destroyBlock(pos, drops);
-                }
-                else {
-                    float chance = Config.COMMON.gameplay.griefing.breakingChance.get().floatValue();
-                    if (Math.random() < chance) this.level.destroyBlock(pos, drops);
-                }
+                if (Math.random() < chance) this.level.destroyBlock(pos, Config.COMMON.gameplay.griefing.fragileDrops.get());
             }
 
             if(!state.getMaterial().isReplaceable())

--- a/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
@@ -435,7 +435,7 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
             if(Config.COMMON.gameplay.griefing.enableGlassBreaking.get() && state.is(ModTags.Blocks.FRAGILE))
             {
                 float destroySpeed = state.getDestroySpeed(this.level, pos);
-                if(destroySpeed > 0)
+                if(destroySpeed >= 0)
                 {
                     float chance = Config.COMMON.gameplay.griefing.fragileBaseBreakChance.get().floatValue() / (destroySpeed + 1);
                     if(this.random.nextFloat() < chance)

--- a/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
@@ -77,7 +77,6 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.random.RandomGenerator;
 
 public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnData
 {
@@ -435,16 +434,15 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
 
             if(Config.COMMON.gameplay.griefing.enableGlassBreaking.get() && state.is(ModTags.Blocks.FRAGILE))
             {
-                float speed = state.getDestroySpeed(getLevel(), pos);
-                // If speed is under 0, it will use the unbreakableHardness value
-                speed = speed < 0 ? Config.COMMON.gameplay.griefing.unbreakableHardness.get().floatValue() : speed;
-                float min = Config.COMMON.gameplay.griefing.guaranteeMinimum.get().floatValue();
-                // If min is under 0, it will still be 0 for this calculation
-                float total = speed - Math.max(0.0f, min);
-                // If min is over or equal to speed (and so total is negative or zero) 100% chance, otherwise, do the normal calculation
-                float chance = speed <= min ? 1.0f : (Config.COMMON.gameplay.griefing.breakingChance.get().floatValue() / (total+1));
-
-                if (Math.random() < chance) this.level.destroyBlock(pos, Config.COMMON.gameplay.griefing.fragileDrops.get());
+                float destroySpeed = state.getDestroySpeed(this.level, pos);
+                if(destroySpeed > 0)
+                {
+                    float chance = Config.COMMON.gameplay.griefing.fragileBaseBreakChance.get().floatValue() / (destroySpeed + 1);
+                    if(this.random.nextFloat() < chance)
+                    {
+                        this.level.destroyBlock(pos, Config.COMMON.gameplay.griefing.fragileBlockDrops.get());
+                    }
+                }
             }
 
             if(!state.getMaterial().isReplaceable())


### PR DESCRIPTION
Added a new "fragile" tag

This tag include all glasses + some extra blocks that wouldn't stand bullets in real life

Added new config, namely :
Boolean - Fragile blocks drop
Float - Breaking Chance
Boolean - Change breaking chance depending of block's strength Float - Make it so blocks of a certain strength will be instantly broken (-1 to disable)
Float - The value unbreakable blocks have when they are fragile (-1 breaks the system so it's the only fix I could think of other then hardcodding it)