### PR TITLE
Allow for more control over attachment application

### DIFF
--- a/src/main/java/com/mrcrayfish/guns/common/container/slot/AttachmentSlot.java
+++ b/src/main/java/com/mrcrayfish/guns/common/container/slot/AttachmentSlot.java
@@ -52,7 +52,11 @@ public class AttachmentSlot extends Slot
         }
         GunItem item = (GunItem) this.weapon.getItem();
         Gun modifiedGun = item.getModifiedGun(this.weapon);
-        return stack.getItem() instanceof IAttachment && ((IAttachment) stack.getItem()).getType() == this.type && modifiedGun.canAttachType(this.type);
+        if (!(stack.getItem() instanceof IAttachment attachment))
+        {
+            return false;
+        }
+        return attachment.getType() == this.type && modifiedGun.canAttachType(this.type) && attachment.canAttachTo(this.weapon);
     }
 
     @Override

--- a/src/main/java/com/mrcrayfish/guns/item/attachment/IAttachment.java
+++ b/src/main/java/com/mrcrayfish/guns/item/attachment/IAttachment.java
@@ -1,6 +1,7 @@
 package com.mrcrayfish.guns.item.attachment;
 
 import com.mrcrayfish.guns.item.attachment.impl.Attachment;
+import net.minecraft.world.item.ItemStack;
 
 import javax.annotation.Nullable;
 
@@ -20,6 +21,15 @@ public interface IAttachment<T extends Attachment>
      * @return The additional properties about this attachment
      */
     T getProperties();
+
+    /**
+     * @param stack Weapon stack
+     * @return If attachment can be attached to gun
+     */
+    default boolean canAttachTo(ItemStack stack)
+    {
+        return true;
+    }
 
     enum Type
     {


### PR DESCRIPTION
Adds simple ``canAttachTo(ItemStack)`` hook to allow add-ons to partial control if attachment is applicable to weapon.

**Use-case explained:**
In Additional Guns we have a rather large scope (unimplemented because of this) that only fits on the biggest sniper rifles. Having the ability to control on which guns the scope fits would fix all the visual issues caused by applying said scope to something like a pistol.