### PR TITLE
Fix Bug and Add More Gun Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ eclipse
 run
 logs
 libs
+.vscode
 
 classes
 src/generated/resources/.cache/*

--- a/src/generated/resources/data/cgm/guns/assault_rifle.json
+++ b/src/generated/resources/data/cgm/guns/assault_rifle.json
@@ -9,11 +9,12 @@
     "auto": true,
     "gripType": "cgm:two_handed",
     "maxAmmo": 40,
-    "rate": 3,
+    "rate": 10,
     "recoilAngle": 3.0,
     "recoilKick": 0.25,
     "reloadAmount": 10,
-    "spread": 4.0
+    "spread": 1.0,
+    "projectileBurst": 5
   },
   "modules": {
     "attachments": {

--- a/src/generated/resources/data/cgm/guns/heavy_rifle.json
+++ b/src/generated/resources/data/cgm/guns/heavy_rifle.json
@@ -15,7 +15,8 @@
     "recoilAngle": 10.0,
     "recoilDurationOffset": 0.5,
     "recoilKick": 1.0,
-    "spread": 1.0
+    "spread": 1.0,
+    "recoilDuration": 20.0
   },
   "modules": {
     "attachments": {

--- a/src/generated/resources/data/cgm/guns/machine_pistol.json
+++ b/src/generated/resources/data/cgm/guns/machine_pistol.json
@@ -16,7 +16,8 @@
     "recoilAngle": 4.0,
     "recoilKick": 0.25,
     "reloadAmount": 20,
-    "spread": 6.0
+    "spread": 1.0,
+    "recoilRadian": 0.5
   },
   "modules": {
     "attachments": {

--- a/src/main/java/com/mrcrayfish/guns/client/handler/RecoilHandler.java
+++ b/src/main/java/com/mrcrayfish/guns/client/handler/RecoilHandler.java
@@ -38,6 +38,9 @@ public class RecoilHandler
     private float gunRecoilRandom;
     private float cameraRecoil;
     private float progressCameraRecoil;
+    private float duration;
+    private float xrecoil;
+    private float yrecoil;
 
     private RecoilHandler() {}
 
@@ -58,6 +61,11 @@ public class RecoilHandler
         this.cameraRecoil = modifiedGun.getGeneral().getRecoilAngle() * recoilModifier;
         this.progressCameraRecoil = 0F;
         this.gunRecoilRandom = random.nextFloat();
+        this.duration = modifiedGun.getGeneral().getRecoilDuration();
+        float offsetRadian = modifiedGun.getGeneral().getRecoilRadian();
+        if (offsetRadian > 0.0F) offsetRadian = this.random.nextFloat(-offsetRadian, offsetRadian);
+        xrecoil = this.cameraRecoil * (float)Math.cos(offsetRadian);
+        yrecoil = this.cameraRecoil * (float)Math.sin(offsetRadian);
     }
 
     @SubscribeEvent
@@ -73,18 +81,21 @@ public class RecoilHandler
         if(!Config.SERVER.enableCameraRecoil.get())
             return;
 
-        float recoilAmount = this.cameraRecoil * mc.getDeltaFrameTime() * 0.15F;
+        float recoilAmount = this.cameraRecoil * mc.getDeltaFrameTime() / this.duration;
         float startProgress = this.progressCameraRecoil / this.cameraRecoil;
         float endProgress = (this.progressCameraRecoil + recoilAmount) / this.cameraRecoil;
 
         float pitch = mc.player.getXRot();
+        float yaw = mc.player.getYRot();
         if(startProgress < 0.2F)
         {
-            mc.player.setXRot(pitch - ((endProgress - startProgress) / 0.2F) * this.cameraRecoil);
+            mc.player.setXRot(pitch - ((endProgress - startProgress) / 0.2F) * this.xrecoil);
+            mc.player.setYRot(yaw - ((endProgress - startProgress) / 0.2F) * this.yrecoil);
         }
         else
         {
-            mc.player.setXRot(pitch + ((endProgress - startProgress) / 0.8F) * this.cameraRecoil);
+            mc.player.setXRot(pitch + ((endProgress - startProgress) / 0.8F) * this.xrecoil);
+            mc.player.setYRot(yaw + ((endProgress - startProgress) / 0.8F) * this.yrecoil);
         }
 
         this.progressCameraRecoil += recoilAmount;

--- a/src/main/java/com/mrcrayfish/guns/client/handler/ShootingHandler.java
+++ b/src/main/java/com/mrcrayfish/guns/client/handler/ShootingHandler.java
@@ -179,7 +179,7 @@ public class ShootingHandler
             ItemStack heldItem = player.getMainHandItem();
             if(heldItem.getItem() instanceof GunItem)
             {
-                if(mc.options.keyAttack.isDown())
+                if(mc.options.keyAttack.isDown() || heldItem.getTag().getInt("burstCount") > 0)
                 {
                     Gun gun = ((GunItem) heldItem.getItem()).getModifiedGun(heldItem);
                     if(gun.getGeneral().isAuto())

--- a/src/main/java/com/mrcrayfish/guns/client/handler/ShootingHandler.java
+++ b/src/main/java/com/mrcrayfish/guns/client/handler/ShootingHandler.java
@@ -76,8 +76,11 @@ public class ShootingHandler
             {
                 event.setSwingHand(false);
                 event.setCanceled(true);
-                this.fire(player, heldItem);
                 Gun gun = gunItem.getModifiedGun(heldItem);
+                if(gun.getGeneral().getProjectileBurst() == 1)
+                {
+                    this.fire(player, heldItem);
+                }
                 if(!gun.getGeneral().isAuto())
                 {
                     mc.options.keyAttack.setDown(false);

--- a/src/main/java/com/mrcrayfish/guns/client/handler/ShootingHandler.java
+++ b/src/main/java/com/mrcrayfish/guns/client/handler/ShootingHandler.java
@@ -76,15 +76,6 @@ public class ShootingHandler
             {
                 event.setSwingHand(false);
                 event.setCanceled(true);
-                Gun gun = gunItem.getModifiedGun(heldItem);
-                if(gun.getGeneral().getProjectileBurst() == 1)
-                {
-                    this.fire(player, heldItem);
-                }
-                if(!gun.getGeneral().isAuto())
-                {
-                    mc.options.keyAttack.setDown(false);
-                }
             }
         }
         else if(event.isUseItem())
@@ -185,9 +176,10 @@ public class ShootingHandler
                 if(mc.options.keyAttack.isDown() || heldItem.getTag().getInt("burstCount") > 0)
                 {
                     Gun gun = ((GunItem) heldItem.getItem()).getModifiedGun(heldItem);
-                    if(gun.getGeneral().isAuto())
+                    this.fire(player, heldItem);
+                    if(!gun.getGeneral().isAuto())
                     {
-                        this.fire(player, heldItem);
+                        mc.options.keyAttack.setDown(false);
                     }
                 }
             }

--- a/src/main/java/com/mrcrayfish/guns/common/Gun.java
+++ b/src/main/java/com/mrcrayfish/guns/common/Gun.java
@@ -111,6 +111,10 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         @Optional
         private float recoilAngle;
         @Optional
+        private float recoilRadian = 0.0F;
+        @Optional
+        private float recoilDuration = 6.67F;
+        @Optional
         private float recoilKick;
         @Optional
         private float recoilDurationOffset;
@@ -137,6 +141,8 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             tag.putInt("MaxAmmo", this.maxAmmo);
             tag.putInt("ReloadSpeed", this.reloadAmount);
             tag.putFloat("RecoilAngle", this.recoilAngle);
+            tag.putFloat("RecoilRadian", this.recoilRadian);
+            tag.putFloat("RecoilDuration", this.recoilDuration);
             tag.putFloat("RecoilKick", this.recoilKick);
             tag.putFloat("RecoilDurationOffset", this.recoilDurationOffset);
             tag.putFloat("RecoilAdsReduction", this.recoilAdsReduction);
@@ -174,6 +180,14 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             if(tag.contains("RecoilAngle", Tag.TAG_ANY_NUMERIC))
             {
                 this.recoilAngle = tag.getFloat("RecoilAngle");
+            }
+            if(tag.contains("RecoilRadian", Tag.TAG_ANY_NUMERIC))
+            {
+                this.recoilRadian = tag.getFloat("RecoilRadian");
+            }
+            if(tag.contains("RecoilDuration", Tag.TAG_ANY_NUMERIC))
+            {
+                this.recoilDuration = tag.getFloat("RecoilDuration");
             }
             if(tag.contains("RecoilKick", Tag.TAG_ANY_NUMERIC))
             {
@@ -215,6 +229,8 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             Preconditions.checkArgument(this.maxAmmo > 0, "Max ammo must be more than zero");
             Preconditions.checkArgument(this.reloadAmount >= 1, "Reload angle must be more than or equal to zero");
             Preconditions.checkArgument(this.recoilAngle >= 0.0F, "Recoil angle must be more than or equal to zero");
+            Preconditions.checkArgument(this.recoilRadian >= 0.0F, "Recoil radian must be more than or equal to zero");
+            Preconditions.checkArgument(this.recoilDuration > 0.0F, "Recoil duration must be more than zero");
             Preconditions.checkArgument(this.recoilKick >= 0.0F, "Recoil kick must be more than or equal to zero");
             Preconditions.checkArgument(this.recoilDurationOffset >= 0.0F && this.recoilDurationOffset <= 1.0F, "Recoil duration offset must be between 0.0 and 1.0");
             Preconditions.checkArgument(this.recoilAdsReduction >= 0.0F && this.recoilAdsReduction <= 1.0F, "Recoil ads reduction must be between 0.0 and 1.0");
@@ -229,6 +245,8 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             object.addProperty("maxAmmo", this.maxAmmo);
             if(this.reloadAmount != 1) object.addProperty("reloadAmount", this.reloadAmount);
             if(this.recoilAngle != 0.0F) object.addProperty("recoilAngle", this.recoilAngle);
+            if(this.recoilRadian != 0.0F) object.addProperty("recoilRadian", this.recoilRadian);
+            if(this.recoilDuration != 6.67F) object.addProperty("recoilDuration", this.recoilDuration);
             if(this.recoilKick != 0.0F) object.addProperty("recoilKick", this.recoilKick);
             if(this.recoilDurationOffset != 0.0F) object.addProperty("recoilDurationOffset", this.recoilDurationOffset);
             if(this.recoilAdsReduction != 0.2F) object.addProperty("recoilAdsReduction", this.recoilAdsReduction);
@@ -252,6 +270,8 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             general.maxAmmo = this.maxAmmo;
             general.reloadAmount = this.reloadAmount;
             general.recoilAngle = this.recoilAngle;
+            general.recoilRadian = this.recoilRadian;
+            general.recoilDuration = this.recoilDuration;
             general.recoilKick = this.recoilKick;
             general.recoilDurationOffset = this.recoilDurationOffset;
             general.recoilAdsReduction = this.recoilAdsReduction;
@@ -309,6 +329,22 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         public float getRecoilAngle()
         {
             return this.recoilAngle;
+        }
+
+        /**
+         * @return A radian that recoil may offset from vertical
+         */
+        public float getRecoilRadian()
+        {
+            return this.recoilRadian;
+        }
+
+        /**
+         * @return The amount of recoil ticks
+         */
+        public float getRecoilDuration()
+        {
+            return this.recoilDuration;
         }
 
         /**
@@ -1659,6 +1695,18 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         public Builder setRecoilAngle(float recoilAngle)
         {
             this.gun.general.recoilAngle = recoilAngle;
+            return this;
+        }
+
+        public Builder setRecoilRadian(float recoilRadian)
+        {
+            this.gun.general.recoilRadian = recoilRadian;
+            return this;
+        }
+
+        public Builder setRecoilDuration(float recoilDuration)
+        {
+            this.gun.general.recoilDuration = recoilDuration;
             return this;
         }
 

--- a/src/main/java/com/mrcrayfish/guns/common/Gun.java
+++ b/src/main/java/com/mrcrayfish/guns/common/Gun.java
@@ -119,6 +119,8 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         @Optional
         private int projectileAmount = 1;
         @Optional
+        private int projectileBurst = 1;
+        @Optional
         private boolean alwaysSpread;
         @Optional
         private float spread;
@@ -139,6 +141,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             tag.putFloat("RecoilDurationOffset", this.recoilDurationOffset);
             tag.putFloat("RecoilAdsReduction", this.recoilAdsReduction);
             tag.putInt("ProjectileAmount", this.projectileAmount);
+            tag.putInt("ProjectileBurst", this.projectileBurst);
             tag.putBoolean("AlwaysSpread", this.alwaysSpread);
             tag.putFloat("Spread", this.spread);
             tag.putFloat("SpreadAdsReduction", this.spreadAdsReduction);
@@ -188,6 +191,10 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             {
                 this.projectileAmount = tag.getInt("ProjectileAmount");
             }
+            if(tag.contains("ProjectileBurst", Tag.TAG_ANY_NUMERIC))
+            {
+                this.projectileBurst = tag.getInt("ProjectileBurst");
+            }
             if(tag.contains("AlwaysSpread", Tag.TAG_ANY_NUMERIC))
             {
                 this.alwaysSpread = tag.getBoolean("AlwaysSpread");
@@ -212,6 +219,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             Preconditions.checkArgument(this.recoilDurationOffset >= 0.0F && this.recoilDurationOffset <= 1.0F, "Recoil duration offset must be between 0.0 and 1.0");
             Preconditions.checkArgument(this.recoilAdsReduction >= 0.0F && this.recoilAdsReduction <= 1.0F, "Recoil ads reduction must be between 0.0 and 1.0");
             Preconditions.checkArgument(this.projectileAmount >= 1, "Projectile amount must be more than or equal to one");
+            Preconditions.checkArgument(this.projectileBurst >= 1, "Projectile burst must be more than or equal to one");
             Preconditions.checkArgument(this.spread >= 0.0F, "Spread must be more than or equal to zero");
             Preconditions.checkArgument(this.spreadAdsReduction >= 0.0F && this.spreadAdsReduction <= 1.0F, "Spread ads reduction must be between 0.0 and 1.0");
             JsonObject object = new JsonObject();
@@ -225,6 +233,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             if(this.recoilDurationOffset != 0.0F) object.addProperty("recoilDurationOffset", this.recoilDurationOffset);
             if(this.recoilAdsReduction != 0.2F) object.addProperty("recoilAdsReduction", this.recoilAdsReduction);
             if(this.projectileAmount != 1) object.addProperty("projectileAmount", this.projectileAmount);
+            if(this.projectileBurst != 1) object.addProperty("projectileBurst", this.projectileBurst);
             if(this.alwaysSpread) object.addProperty("alwaysSpread", true);
             if(this.spread != 0.0F) object.addProperty("spread", this.spread);
             if(this.spreadAdsReduction != 0.5F) object.addProperty("spreadAdsReduction", this.spreadAdsReduction);
@@ -247,6 +256,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             general.recoilDurationOffset = this.recoilDurationOffset;
             general.recoilAdsReduction = this.recoilAdsReduction;
             general.projectileAmount = this.projectileAmount;
+            general.projectileBurst = this.projectileBurst;
             general.alwaysSpread = this.alwaysSpread;
             general.spread = this.spread;
             general.spreadAdsReduction = this.spreadAdsReduction;
@@ -331,6 +341,14 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         public int getProjectileAmount()
         {
             return this.projectileAmount;
+        }
+
+        /**
+         * @return The count of projectiles this weapon fires at a strike
+         */
+        public int getProjectileBurst()
+        {
+            return this.projectileBurst;
         }
 
         /**
@@ -1665,6 +1683,12 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         public Builder setProjectileAmount(int projectileAmount)
         {
             this.gun.general.projectileAmount = projectileAmount;
+            return this;
+        }
+
+        public Builder setProjectileBurst(int projectileBurst)
+        {
+            this.gun.general.projectileBurst = projectileBurst;
             return this;
         }
 

--- a/src/main/java/com/mrcrayfish/guns/common/Gun.java
+++ b/src/main/java/com/mrcrayfish/guns/common/Gun.java
@@ -122,6 +122,8 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         private boolean alwaysSpread;
         @Optional
         private float spread;
+        @Optional
+        private float spreadAdsReduction = 0.5F;
 
         @Override
         public CompoundTag serializeNBT()
@@ -139,6 +141,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             tag.putInt("ProjectileAmount", this.projectileAmount);
             tag.putBoolean("AlwaysSpread", this.alwaysSpread);
             tag.putFloat("Spread", this.spread);
+            tag.putFloat("SpreadAdsReduction", this.spreadAdsReduction);
             return tag;
         }
 
@@ -193,6 +196,10 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             {
                 this.spread = tag.getFloat("Spread");
             }
+            if(tag.contains("SpreadAdsReduction", Tag.TAG_ANY_NUMERIC))
+            {
+                this.spreadAdsReduction = tag.getFloat("SpreadAdsReduction");
+            }
         }
 
         public JsonObject toJsonObject()
@@ -206,6 +213,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             Preconditions.checkArgument(this.recoilAdsReduction >= 0.0F && this.recoilAdsReduction <= 1.0F, "Recoil ads reduction must be between 0.0 and 1.0");
             Preconditions.checkArgument(this.projectileAmount >= 1, "Projectile amount must be more than or equal to one");
             Preconditions.checkArgument(this.spread >= 0.0F, "Spread must be more than or equal to zero");
+            Preconditions.checkArgument(this.spreadAdsReduction >= 0.0F && this.spreadAdsReduction <= 1.0F, "Spread ads reduction must be between 0.0 and 1.0");
             JsonObject object = new JsonObject();
             if(this.auto) object.addProperty("auto", true);
             object.addProperty("rate", this.rate);
@@ -219,6 +227,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             if(this.projectileAmount != 1) object.addProperty("projectileAmount", this.projectileAmount);
             if(this.alwaysSpread) object.addProperty("alwaysSpread", true);
             if(this.spread != 0.0F) object.addProperty("spread", this.spread);
+            if(this.spreadAdsReduction != 0.5F) object.addProperty("spreadAdsReduction", this.spreadAdsReduction);
             return object;
         }
 
@@ -240,6 +249,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
             general.projectileAmount = this.projectileAmount;
             general.alwaysSpread = this.alwaysSpread;
             general.spread = this.spread;
+            general.spreadAdsReduction = this.spreadAdsReduction;
             return general;
         }
 
@@ -308,7 +318,7 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         }
 
         /**
-         * @return The amount of reduction applied when aiming down this weapon's sight
+         * @return The amount of recoil reduction applied when aiming down this weapon's sight
          */
         public float getRecoilAdsReduction()
         {
@@ -338,6 +348,14 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         public float getSpread()
         {
             return this.spread;
+        }
+
+        /**
+         * @return The amount of spread reduction allpied when aiming down this weapon's sight
+         */
+        public float getSpreadAdsReduction()
+        {
+            return this.spreadAdsReduction;
         }
     }
 
@@ -1659,6 +1677,12 @@ public class Gun implements INBTSerializable<CompoundTag>, IEditorMenu
         public Builder setSpread(float spread)
         {
             this.gun.general.spread = spread;
+            return this;
+        }
+
+        public Builder setSpreadAdsReduction(float spreadAdsReduction)
+        {
+            this.gun.general.spreadAdsReduction = spreadAdsReduction;
             return this;
         }
 

--- a/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/mrcrayfish/guns/entity/ProjectileEntity.java
@@ -178,7 +178,7 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
 
             if(ModSyncedDataKeys.AIMING.getValue((Player) shooter))
             {
-                gunSpread *= 0.5F;
+                gunSpread *= (1.0F - modifiedGun.getGeneral().getSpreadAdsReduction());
             }
         }
 

--- a/src/main/java/com/mrcrayfish/guns/init/ModRecipeTypes.java
+++ b/src/main/java/com/mrcrayfish/guns/init/ModRecipeTypes.java
@@ -15,9 +15,9 @@ public class ModRecipeTypes
 {
     public static final DeferredRegister<RecipeType<?>> REGISTER = DeferredRegister.create(ForgeRegistries.RECIPE_TYPES, Reference.MOD_ID);
 
-    public static final RegistryObject<RecipeType<WorkbenchRecipe>> WORKBENCH = create("workbench");
+    public static final RegistryObject<RecipeType<Recipe<?>>> WORKBENCH = create("workbench");
 
-    private static <T extends Recipe<?>> RegistryObject<RecipeType<T>> create(String name)
+    private static <T extends Recipe<?>> RegistryObject<RecipeType<Recipe<?>>> create(String name)
     {
         return REGISTER.register(name, () -> new RecipeType<>()
         {

--- a/src/main/java/com/mrcrayfish/guns/util/GunEnchantmentHelper.java
+++ b/src/main/java/com/mrcrayfish/guns/util/GunEnchantmentHelper.java
@@ -5,6 +5,7 @@ import com.mrcrayfish.guns.init.ModEnchantments;
 import com.mrcrayfish.guns.particles.TrailData;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -50,6 +51,14 @@ public class GunEnchantmentHelper
         {
             float newRate = rate * (0.25F * level);
             rate -= Mth.clamp(newRate, 0, rate);
+        }
+        CompoundTag tag = weapon.getTag();
+        if (tag != null)
+        {
+            int burstCount = tag.getInt("burstCount") + 1;
+            if (burstCount < modifiedGun.getGeneral().getProjectileBurst()) rate = 1;
+            else burstCount = 0;
+            tag.putInt("burstCount", burstCount);
         }
         return rate;
     }


### PR DESCRIPTION
**Bug fix**
 
- remove `fire` in `onMouseClick` to avoid two shots in one tick

**More Options**

- `spreadAdsReduction`, like `recoilAdsReduction`, it can reduce spread when aiming, default 0.5
- `projectileBurst`, gun can shoot several times in a short time, default 1
- `recoilDuration`, change the number of ticks the recoil persists, default 6.67
- `recoilRadian`, change the recoil direction in radian, default 0

All these default values are the same effect with the previous version. Some json files are modified to show the change

**Other**

- add `.vscode` to `.gitignore`
- `ModRecipeTypes.java` has an error in my vscode and it auto fixes it, I also asked this in discord
